### PR TITLE
Added support for mapping DS3 buttons to directions on the analog sticks

### DIFF
--- a/ScpControl/ScpCore/GamePadEnums.cs
+++ b/ScpControl/ScpCore/GamePadEnums.cs
@@ -182,6 +182,19 @@ namespace ScpControl.ScpCore
         Square = 33
     }
 
+    public enum Ds3AnalogDirection
+    {
+        LUp = -15,
+        LRight = 14,
+        LDown = 15,
+        LLeft = -14,
+
+        RUp = -17,
+        RRight = 16,
+        RDown = 17,
+        RLeft = -16
+    }
+
     [Flags]
     public enum Ds4Button : uint
     {

--- a/ScpControl/ScpCore/Profile.cs
+++ b/ScpControl/ScpCore/Profile.cs
@@ -13,6 +13,7 @@ namespace ScpControl.ScpCore
     {
         private readonly Ds3AxisMap _ds3AxisMap = new Ds3AxisMap();
         private readonly Ds3ButtonMap _ds3ButtonMap = new Ds3ButtonMap();
+        private readonly Ds3ButtonAnalogDirectionMap _ds3ButtonAnalogDirectionMap = new Ds3ButtonAnalogDirectionMap();
         private readonly Ds4AxisMap _ds4AxisMap = new Ds4AxisMap();
         private readonly Ds4ButtonMap _ds4ButtonMap = new Ds4ButtonMap();
         private readonly DsMatch _match = DsMatch.Global;
@@ -82,6 +83,11 @@ namespace ScpControl.ScpCore
         public Ds3AxisMap Ds3Axis
         {
             get { return _ds3AxisMap; }
+        }
+
+        public Ds3ButtonAnalogDirectionMap Ds3ButtonAnalogDirection
+        {
+            get { return _ds3ButtonAnalogDirectionMap; }
         }
 
         public Ds4ButtonMap Ds4Button

--- a/ScpControl/ScpMapper.xml
+++ b/ScpControl/ScpMapper.xml
@@ -12,6 +12,7 @@
       <DS3>
         <Button />
         <Axis />
+        <ButtonAnalogDirection />
       </DS3>
       <DS4>
         <Button />
@@ -28,6 +29,7 @@
           <L2>None</L2>
           <R2>None</R2>
         </Axis>
+        <ButtonAnalogDirection />
       </DS3>
       <DS4>
         <Button />
@@ -56,6 +58,7 @@
           <L1>R1</L1>
           <R1>L1</R1>
         </Axis>
+        <ButtonAnalogDirection />
       </DS3>
       <DS4>
         <Button>
@@ -87,6 +90,7 @@
           <L2>None</L2>
           <R2>None</R2>
         </Axis>
+        <ButtonAnalogDirection />
       </DS3>
       <DS4>
         <Button>
@@ -118,6 +122,7 @@
           <L1>None</L1>
           <R1>None</R1>
         </Axis>
+        <ButtonAnalogDirection />
       </DS3>
       <DS4>
         <Button>

--- a/ScpControl/ScpUtil.cs
+++ b/ScpControl/ScpUtil.cs
@@ -23,6 +23,10 @@ namespace ScpControl
     {
     }
 
+    public class Ds3ButtonAnalogDirectionMap : SortedDictionary<Ds3Button, Ds3AnalogDirection>
+    {
+    }
+
     public class Ds4ButtonMap : SortedDictionary<Ds4Button, Ds4Button>
     {
     }

--- a/ScpControl/XmlMapper.cs
+++ b/ScpControl/XmlMapper.cs
@@ -392,6 +392,8 @@ namespace ScpControl
 
                 foreach (var item in profile.Ds3Button.Keys.Where(item => (Out[0] & item) != Ds3Button.None))
                     Out[0] ^= item;
+                foreach (var item in profile.Ds3ButtonAnalogDirection.Keys.Where(item => (Out[0] & item) != Ds3Button.None))
+                    Out[0] ^= item;
                 Out[0] = profile.Ds3Button.Keys.Where(item => (In & item) != Ds3Button.None).Aggregate(Out[0], (current, item) => current | profile.Ds3Button[item]);
 
                 output[10] = (byte) ((uint) Out[0] >> 0 & 0xFF);
@@ -423,9 +425,6 @@ namespace ScpControl
                 }
 
                 // Map analog direction
-                foreach (var item in profile.Ds3ButtonAnalogDirection.Keys.Where(item => (Out[0] & item) != Ds3Button.None))
-                    Out[0] ^= item;
-
                 foreach (var item in profile.Ds3ButtonAnalogDirection.Values)
                     output[Math.Abs((int)item)] = 127;
 


### PR DESCRIPTION
Currently the ScpMapper.xml interface only supports remapping buttons to other buttons and axes to other axes. This change specifically addresses a use-case where the user may want to map d-pad buttons to analog stick directions by allowing the user to map any button to analog stick directions. I personally came across the need for this feature when playing RPGMaker games with my DS3 controller.

I tried to follow existing conventions when implementing this feature, but I wanted to note the following.

* I tried implementing this a few different ways, and I think I came up with a pretty elegant solution. However, I came to this after only a few hours perusing and playing with the code. I am open to criticism and suggestions.
* I only implemented the mappings for the DS3. I can probably do the same for the DS4, but I don't have a controller to test with.
* Because of the way the XML parsing logic is written, the new &lt;ButtonAnalogDirection&gt; XML section needs to exist in every &lt;DS3&gt; section in the ScpMapper.xml file or else the mapper won't be able to read any mappings. This could potentially break a user's custom profiles during an upgrade if they attempt to use their existing ScpMapper.xml file.