### PR TITLE
Fix thread pileup handling timer ticks with USB devices.

### DIFF
--- a/ScpControl/Usb/UsbDevice.cs
+++ b/ScpControl/Usb/UsbDevice.cs
@@ -75,9 +75,16 @@ namespace ScpControl.Usb
 
         private void On_Timer(object sender, EventArgs e)
         {
-            lock (this)
+            if (Monitor.TryEnter(this))
             {
-                Process(DateTime.Now);
+                try
+                {
+                    Process(DateTime.Now);
+                }
+                finally
+                {
+                    Monitor.Exit(this);
+                }
             }
         }
 


### PR DESCRIPTION
It looks like the input hangs with rumble (issues 70 and 59) and out-of-control thread counts (issue 57) were due to the timer threads piling up. Since the tick handler seems to be for updating the LED, it ought to be safe to drop some ticks if the previous handler is still running. This solves the thread pileup for USB devices. I don't have a bluetooth device to see if the same issue happens there, so I made no changes to the BT device code.